### PR TITLE
Add support for CC2530, and update PyUSB usage

### DIFF
--- a/99-ccsniffer.rules
+++ b/99-ccsniffer.rules
@@ -1,2 +1,3 @@
 ATTR{idVendor}=="0451", ATTR{idProduct}=="16ae", OWNER="root", GROUP="plugdev", MODE="0666"
+ATTR{idVendor}=="11a0", ATTR{idProduct}=="eb20", OWNER="root", GROUP="plugdev", MODE="0666"
 


### PR DESCRIPTION
This commit adds support for the CC2530 USB dongle, which has
different USB vendor/product IDs, and also uses endpoint 0x82
rather than 0x83 for data transfer.

If a CC2531 USB device is not found, then an attempt to detect
a CC2530 device is made instead - so either dongle will be
detected.